### PR TITLE
Display only last membership by default

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -350,6 +350,33 @@ button[disabled] {
 }
 /* endregion */
 
+/* region Lookup */
+#display-only-valid-memberships:has(input:checked) ~ #memberships .membership:not(.membership-valid) {
+    /* When the checkbox is checked, hide invalid memberships */
+    @apply hidden
+}
+
+#memberships.no-membership-found {
+    @apply hidden
+}
+
+#memberships.no-membership-found ~ #no-membership-found {
+    @apply block
+}
+
+#memberships.no-membership-found ~ #go-to-send-email-step {
+    @apply hidden
+}
+
+#display-only-valid-memberships:has(~ #memberships.no-membership-found) {
+    @apply hidden
+}
+
+#no-membership-found {
+    @apply hidden
+}
+/* endregion */
+
 :has(> .hide-parent-if-empty:empty) {
     @apply hidden
 }

--- a/public/templates/member/lookup-member.html.tera
+++ b/public/templates/member/lookup-member.html.tera
@@ -23,7 +23,15 @@
         </div>
 
         <div class="step">
+            <div id="display-only-valid-memberships">
+                <label>
+                    Afficher uniquement les licences valides <input type="checkbox" checked>
+                </label>
+            </div>
             <div id="memberships" class="memberships">
+            </div>
+            <div id="no-membership-found">
+                Aucune licence n'a été trouvée.
             </div>
             <button type="button" id="go-to-send-email-step" onclick="app.go_to_notification_step(document)" disabled>Notifier les membres cochés</button>
         </div>

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
 name = "wasm"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "console_error_panic_hook",
  "csv",
  "dto",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1.0.218", features = ["derive"] }
 log = "0.4.26"
 serde-json-wasm = "1.0.1"
 csv = "1.3.1"
+chrono = "0.4.41"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"

--- a/wasm/src/card_creator.rs
+++ b/wasm/src/card_creator.rs
@@ -4,6 +4,7 @@ use crate::template::get_template;
 use crate::utils::{
     add_class, append_child, create_element, query_selector_single_element, set_attribute,
 };
+use chrono::Utc;
 use dto::checked_member::{CheckResult, CheckedMember};
 use dto::member_to_check::MemberToCheck;
 use dto::membership::Membership;
@@ -146,6 +147,11 @@ pub fn create_known_membership_card(
             .dyn_into::<HtmlAnchorElement>()?;
     email_address_container.set_inner_html(membership.email_address());
     email_address_container.set_href(&format!("mailto:{}", &membership.email_address()));
+
+    let today = Utc::now().date_naive();
+    if membership.start_date() <= &today && &today <= membership.end_date() {
+        add_class(&card, "membership-valid");
+    }
 
     Ok(card)
 }

--- a/wasm/src/lookup.rs
+++ b/wasm/src/lookup.rs
@@ -8,7 +8,8 @@ use crate::error::{DEFAULT_ERROR_MESSAGE, Error};
 use crate::json;
 use crate::user_interface::with_loading;
 use crate::utils::{
-    append_child, clear_element, get_element_by_id, get_element_by_id_dyn, get_value_from_element,
+    add_class, append_child, clear_element, get_element_by_id, get_element_by_id_dyn,
+    get_value_from_element, remove_class,
 };
 use crate::web::fetch;
 use dto::member_to_look_up::MemberToLookUp;
@@ -108,10 +109,15 @@ pub async fn lookup(document: &Document) {
 
 fn display_memberships(document: &Document, memberships: &[Membership]) -> Result<()> {
     let memberships_container = get_element_by_id(document, "memberships")?;
-    clear_element(&memberships_container);
-    for membership in memberships {
-        let card = create_known_membership_card(document, membership)?;
-        append_child(&memberships_container, &card)?;
+    if memberships.is_empty() {
+        add_class(&memberships_container, "no-membership-found");
+    } else {
+        clear_element(&memberships_container);
+        remove_class(&memberships_container, "no-membership-found");
+        for membership in memberships {
+            let card = create_known_membership_card(document, membership)?;
+            append_child(&memberships_container, &card)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a checkbox to filter and display only valid memberships in the lookup interface.
  - Introduced a visual indicator for currently valid memberships.
  - Added a message to inform users when no memberships are found.

- **Bug Fixes**
  - Improved dynamic display logic for membership lists and related UI elements based on search results.

- **Chores**
  - Updated internal dependencies to enhance functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->